### PR TITLE
docs: Fix consistent project name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-PRESENT Formkl - Form Markup Language
+Copyright (c) 2022-PRESENT Formkl - Form marKup Language
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/docs/why.md
+++ b/docs/why.md
@@ -7,7 +7,7 @@ Form is an essential module in any web application. It is used to collect data f
 **Management applications** tend to have a lot of forms for CRUD operations. The more forms you have, the more time you spend on creating them. And the more time you spend on creating them, the less time you spend on developing the core features of your application.
 
 ## The solution
-The Form Markup Language (Formkl) ecosystem is creating a new way that is fast, consistent, and easy way to create forms.
+The Form marKup Language (Formkl) ecosystem is creating a new way that is fast, consistent, and easy way to create forms.
 
 - Extremely lightweight, no dependencies.
 - Provided a strong ecosystem, including renderers that suits your favourite UI frameworks.

--- a/extensions/vscode/LICENSE
+++ b/extensions/vscode/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-PRESENT Formkl - Form Markup Language
+Copyright (c) 2022-PRESENT Formkl - Form marKup Language
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/adapters/vue/README.md
+++ b/packages/adapters/vue/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/elemento/README.md
+++ b/packages/elemento/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/language/README.md
+++ b/packages/language/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/plugins/vite/README.md
+++ b/packages/plugins/vite/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/plugins/webpack/README.md
+++ b/packages/plugins/webpack/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -12,7 +12,7 @@ View sandbox: [sandbox.formkl.org](https://sandbox.formkl.org)
 
 Please make sure to read the [Contributing Guide](https://formkl.org/learning/contribution-guide.html) before making a pull request.
 
-Thank you to all the people who already contributed to the Formkl - Form Markup Language project!
+Thank you to all the people who already contributed to the Formkl - Form marKup Language project!
 
 <a href="https://github.com/imrim12/formkl/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=imrim12/formkl" />


### PR DESCRIPTION
# Description

- As a developer, I want to see the full name of the project consistently in docs.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
